### PR TITLE
Require reauth before updating onboarding email

### DIFF
--- a/lib/features/onboarding/onboarding_controller.dart
+++ b/lib/features/onboarding/onboarding_controller.dart
@@ -423,6 +423,7 @@ class OnboardingController extends StateNotifier<OnboardingState> {
     }
     try {
       User workingUser = FirebaseAuth.instance.currentUser ?? user;
+      final previousEmail = workingUser.email;
       if (displayName != null && displayName.isNotEmpty) {
         await workingUser.updateDisplayName(displayName);
       }
@@ -441,6 +442,20 @@ class OnboardingController extends StateNotifier<OnboardingState> {
           );
         }
       } else if (email != null && email.isNotEmpty && workingUser.email != email) {
+        if (previousEmail == null ||
+            previousEmail.isEmpty ||
+            password == null ||
+            password.isEmpty) {
+          throw FirebaseAuthException(
+            code: 'requires-recent-login',
+            message: 'Debes iniciar sesión nuevamente para actualizar tu correo.',
+          );
+        }
+        final credential = EmailAuthProvider.credential(
+          email: previousEmail,
+          password: password,
+        );
+        await workingUser.reauthenticateWithCredential(credential);
         await workingUser.updateEmail(email);
       }
 


### PR DESCRIPTION
## Summary
- capture the current authenticated email before running onboarding persistence
- require password-based reauthentication before updating a non-anonymous user email and surface a requires-recent-login error when credentials are unavailable

## Testing
- `flutter test` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bf34cb18832aba3e81a090e50692